### PR TITLE
Move to central polling agent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@
 
 pbr<2.0,>=1.6
 Babel>=1.3
--e git+https://git.openstack.org/openstack/ceilometer.git@master#egg=ceilometer

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,12 @@
 [metadata]
 name = ceilometer-infoblox
+version = 0.0.2
 summary = Infoblox custom meters for Ceilometer
 description-file =
     README.rst
-author = OpenStack
-author-email = openstack-dev@lists.openstack.org
-home-page = http://www.openstack.org/
+author = Infoblox, Inc.
+author-email = jbelamaric@infoblox.com
+home-page = https://github.com/infobloxopen/ceilometer-infoblox
 classifier =
     Environment :: OpenStack
     Intended Audience :: Information Technology
@@ -16,7 +17,6 @@ classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
 
 [files]
@@ -49,5 +49,5 @@ output_file = ceilometer_infoblox/locale/ceilometer-infoblox.pot
 ceilometer.discover =
     nios_instances = ceilometer_infoblox.discovery:NIOSDiscovery
 
-ceilometer.poll.compute =
+ceilometer.poll.central =
     nios.dns.qps = ceilometer_infoblox.pollsters.qps:QPSPollster


### PR DESCRIPTION
Since generally the collection of the NIOS SNMP data will be done
over floating IPs, there is no benefit to polling on the compute
nodes. Thus, the entry point is changed to poll from the central
agent, removing the need to install this on the compute nodes.

Additionally, bump the version and thin the requirements (remove
the requirement for the ceilometer git repo).
